### PR TITLE
Implement decoder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ repository = "https://github.com/ssb-ngi-pointer/ssb-bfe-rs"
 [dependencies]
 anyhow = "1.0"
 base64 = "0.13"
-lazy_static = "1.4.0"
-regex = "1"
-serde_json = "1.0"
+indexmap = { version = "1.7.0", features = ["serde"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = { version = "1.0", features = ["preserve_order"] }


### PR DESCRIPTION
 - Add `decode()` capability and helper functions
 - Remove `regex` and `lazy_static` dependencies
   - Perform string manipulations using standard library features (ie. `.rfind()` and `.strip_suffix()`)
 - Rename `ConvertedValue` `enum` to `EncodedValue`
   - Rename variants to match JS expectations (`Array`, `Buffer`, `Object`)
   - Replace `HashMap` with `IndexMap` to preserve field order in key-value objects
 - Add a test to encode and decode a heterogeneous JSON object

More tests and docs tomorrow.